### PR TITLE
Fix in-view-offset by evaluating the attribute so it is actually an integer.

### DIFF
--- a/angular-inview.coffee
+++ b/angular-inview.coffee
@@ -50,7 +50,7 @@ angular.module('angular-inview', [])
 			container?.addItem item
 			if attrs.inViewOffset?
 				attrs.$observe 'inViewOffset', (offset) ->
-					item.offset = offset
+					item.offset = @scope.$eval(offset)
 					do checkInViewDebounced
 			checkInViewItems.push item
 			do checkInViewDebounced

--- a/angular-inview.js
+++ b/angular-inview.js
@@ -75,7 +75,7 @@
         }
         if (attrs.inViewOffset != null) {
           attrs.$observe('inViewOffset', function(offset) {
-            item.offset = offset;
+            item.offset = scope.$eval(offset);
             return checkInViewDebounced();
           });
         }


### PR DESCRIPTION
Previously, if the in-view-offset was set to 100, it would compute the following: 50 + "100" = "50100". Instead, you need to evaluate the offset so it will do 50 + 100 = 150.

This addresses https://github.com/thenikso/angular-inview/issues/4.
