### PR TITLE
added overflowing content detection on triggered in-view

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,16 @@ trigger callbacks when the container scrolls as well as when the window scrolls.
 </div>
 ```
 
+Tell Overflow Example:
+
+```
+<div class="description"
+    in-view="$inview && yourController.highlight(item, $overflowing)"
+    in-view-options="{tellOverflow: true}">
+    <p>{{::item.description}}</p>
+</div>
+```
+
 ## How to contribute
 
 1. Fork the repository and clone it to your machine

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ indicating which part of the DOM element is visible.
 - `$event` is the DOM event that triggered the check; the DOM element that
 changed its visibility status is passed as `$event.inViewTarget`
 (To use the old `$element` variable use version 1.3.x).
+- `$overflowing` is a boolean indicating that the element that is brought into view 
+is cropped/hidden by overflow settings, e.g., overflow: auto, overflow: hidden.
+Set the tellOverflow to true on in-view-options to get a value from $overflowing.
+
 
 An additional attribute `in-view-options` can be speficied with an object value
 containing:
@@ -69,6 +73,9 @@ offset respectively; this may virtually change the height of the element for inv
 - `debounce`: a number indicating a millisecond value of debounce which will delay
 firing the in-view event until that number of millisecond is passed without a scrolling
 event happening.
+- `tellOverflow`: a boolean indicating to check if the element that is brought into view 
+is cropped/hidden by overflow settings, e.g., overflow: auto, overflow: hidden.
+
 
 ### InViewContainer
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "karma-chrome-launcher": "^0.1.12",
     "karma-jasmine": "^0.2.3",
-    "karma-coffee-preprocessor": "^0.2.1",
+    "karma-coffee-preprocessor": "^0.3.0",
     "karma": "^0.12.24"
   },
   "scripts": {


### PR DESCRIPTION
This is used to indicate if the element that is brought into view has
overflowing content in it, e.g., elements that uses **overflow:
auto.**,  used especially for text contents.

Sort of having an in-view within an in-view, albeit the inner view is
detected in advanced if some of its content is partially
cropped/hidden, so the app can visually indicate (with ellipsis for
example) to users that the content they are seeing has information that
is cropped/hidden by the overflow: auto.

This pure CSS text-ellipsis works on one line only:
http://stackoverflow.com/questions/14183887/how-to-make-text-overflow-el
lipsis-work-on-floating-divs

Following pure CSS works on multi-line. Perfect on Safari, works on
both overflown width and height. On Chrome, text ellipsis works on
overflown height only. Does not work on other browsers:

http://codepen.io/martinwolf/pen/qlFdp