### PR TITLE
Added more comprehensive list of events to bind to.

### DIFF
--- a/angular-inview.coffee
+++ b/angular-inview.coffee
@@ -133,13 +133,13 @@ bindWindowEvents = ->
 	# The bind to window events will be added only if actually needed.
 	return if _windowEventsHandlerBinded
 	_windowEventsHandlerBinded = yes
-	angular.element(window).bind 'checkInView click ready scroll resize', windowEventsHandler
+	angular.element(window).bind 'checkInView click ready wheel mousewheel DomMouseScroll MozMousePixelScroll resize scroll touchmove mouseup', windowEventsHandler
 unbindWindowEvents = ->
 	# All the window bindings will be removed if no directive requires to be checked.
 	return unless _windowEventsHandlerBinded
 	return if _windowInViewItems.length or _containersControllers.length
 	_windowEventsHandlerBinded = no
-	angular.element(window).unbind 'checkInView click ready scroll resize', windowEventsHandler
+	angular.element(window).unbind 'checkInView click ready wheel mousewheel DomMouseScroll MozMousePixelScroll resize scroll touchmove mouseup', windowEventsHandler
 
 # ### InView checks
 # This method will call the user defined callback with the proper parameters if neccessary.

--- a/angular-inview.js
+++ b/angular-inview.js
@@ -186,7 +186,7 @@
       return;
     }
     _windowEventsHandlerBinded = true;
-    return angular.element(window).bind('checkInView click ready scroll resize', windowEventsHandler);
+    return angular.element(window).bind('checkInView click ready wheel mousewheel DomMouseScroll MozMousePixelScroll resize scroll touchmove mouseup', windowEventsHandler);
   };
 
   unbindWindowEvents = function() {
@@ -197,7 +197,7 @@
       return;
     }
     _windowEventsHandlerBinded = false;
-    return angular.element(window).unbind('checkInView click ready scroll resize', windowEventsHandler);
+    return angular.element(window).unbind('checkInView click ready wheel mousewheel DomMouseScroll MozMousePixelScroll resize scroll touchmove mouseup', windowEventsHandler);
   };
 
   triggerInViewCallback = function(event, item, inview, isTopVisible, isBottomVisible) {


### PR DESCRIPTION
Fixes #39 
Thanks to @svitzer for the solution from that Issue.

The in-view now triggers when scrolling on an absolutely positioned element (mouse and touch).