### PR TITLE
Fix initial state check

### DIFF
--- a/angular-inview.js
+++ b/angular-inview.js
@@ -45,8 +45,8 @@ function inViewDirective ($parse) {
       //     be included in `$inviewInfo` (default false).
       //   - `generateParts`: Indicate if the `parts` information should
       //     be included in `$inviewInfo` (default false).
-      //   - `throttle`: Spcify a number of milliseconds by which filter the number
-      //     of incoming events.
+      //   - `throttle`: Specify a number of milliseconds by which to limit the
+      //     number of incoming events.
       var options = {};
       if (attrs.inViewOptions) {
         options = scope.$eval(attrs.inViewOptions);
@@ -367,7 +367,7 @@ function signalFromEvent (target, event) {
 
 function signalSingle (value) {
   return new QuickSignal(function (subscriber) {
-    subscriber(value);
+    setTimeout(function() { subscriber(value); });
   });
 }
 

--- a/angular-inview.spec.js
+++ b/angular-inview.spec.js
@@ -245,19 +245,34 @@ describe("angular-inview", function() {
 
 		it("should accept a `throttle` option", function(done) {
 			makeTestForHtml(
-				'<div in-view="spy($inview)"  in-view-options="{ throttle: 200 }"></div>' +
+				'<div in-view="spy($inview)" style="height:100px" in-view-options="{ throttle: 200 }"></div>' +
 				'<div style="height:200%"></div>'
 			)
 			.then(function (test) {
-				expect(test.spy.calls.count()).toBe(0);
+				expect(test.spy.calls.count()).toBe(1);
+				expect(test.spy.calls.mostRecent().args[0]).toBe(true);
 				return test;
 			})
-			.then(lazyWait(200))
+			.then(lazyScrollTo(200))
+			.then(lazyWait(100))
 			.then(function (test) {
 				expect(test.spy.calls.count()).toBe(1);
-				expect(test.spy).toHaveBeenCalledWith(true);
 				return test;
 			})
+			.then(lazyScrollTo(0))
+			.then(lazyWait(100))
+			.then(function (test) {
+				expect(test.spy.calls.count()).toBe(1);
+				return test;
+			})
+			.then(lazyScrollTo(200))
+			.then(lazyWait(100))
+			.then(function (test) {
+				expect(test.spy.calls.count()).toBe(2);
+				expect(test.spy.calls.mostRecent().args[0]).toBe(false);
+				return test;
+			})
+			.then(lazyScrollTo(0))
 			.then(done);
 		});
 


### PR DESCRIPTION
Starting from #109 this PR adds a timeout to the initial check event.

This should let the application render before checking the inview
state of elements.