### PR TITLE
Fix for #102

### DIFF
--- a/angular-inview.js
+++ b/angular-inview.js
@@ -359,9 +359,9 @@ function signalFromEvent (target, event) {
       subscriber(e);
     };
     var el = angular.element(target);
-    el.on(event, handler);
+    el[0].addEventListener(event, handler, true);
     subscriber.$dispose = function () {
-      el.off(event, handler);
+      el[0].removeEventListener(event, handler, true);
     };
   });
 }


### PR DESCRIPTION
Fix for thenikso#102
Issues:

IE 11 not triggering in-view method if click and drag the scrollbar as well as using 'ctrl+end'.
Fixed using vanillaJS addEventListener with 'useCapture' parameter 'true'